### PR TITLE
Using presets to  bring back Intellisense autocomplete 🎉

### DIFF
--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -1,12 +1,9 @@
-const {
-  default: { theme, plugins },
-} = require('@design-system/theme');
+const dsPreset = require('@design-system/theme');
 
 module.exports = {
+  presets: [dsPreset],
   content: [
     './src/**/*.{html,js,jsx,ts,tsx}',
     '../node_modules/@design-system/**/*.{html,tsx, ts, jsx, js}',
   ],
-  theme: theme,
-  plugins: plugins,
 };

--- a/design-system/button/tailwind.config.js
+++ b/design-system/button/tailwind.config.js
@@ -1,9 +1,6 @@
-const {
-  default: { theme, plugins },
-} = require('@design-system/theme');
+const dsPreset = require('@design-system/theme');
 
 module.exports = {
+  presets: [dsPreset],
   content: ['./src/**/*.{html,js,jsx,ts,tsx}'],
-  theme: theme,
-  plugins: plugins,
 };

--- a/design-system/theme/.postcssrc
+++ b/design-system/theme/.postcssrc
@@ -1,5 +1,0 @@
-{
-  "plugins": {
-    "tailwindcss": {}
-  }
-}

--- a/design-system/theme/src/index.css
+++ b/design-system/theme/src/index.css
@@ -1,3 +1,0 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;

--- a/design-system/theme/src/index.ts
+++ b/design-system/theme/src/index.ts
@@ -25,7 +25,7 @@ const neon = {
 
 const colorSchemes = [honey, neon];
 
-const config = {
+export = {
   theme: {
     extend: {
       colors: {
@@ -67,8 +67,8 @@ const config = {
     },
   },
   plugins: [
-    plugin(({ addUtilities }: any) => {
-      const utilities = colorSchemes.map(c => {
+    plugin(({ addBase }: any) => {
+      const themeClasses = colorSchemes.map(c => {
         const { swatch: primarySwatch } = swatchGenerator(c.primary);
         const { swatch: secondarySwatch } = swatchGenerator(c.secondary);
         return {
@@ -103,9 +103,7 @@ const config = {
         };
       });
 
-      addUtilities(utilities);
+      addBase(themeClasses);
     }),
   ],
 } as const;
-
-export default config;

--- a/design-system/theme/tailwind.config.js
+++ b/design-system/theme/tailwind.config.js
@@ -1,7 +1,0 @@
-const { theme, plugins } = require('./src/index');
-
-module.exports = {
-  content: ['./src/**/*.{html,js,jsx,ts,tsx,css}'],
-  theme: theme,
-  plugins: plugins,
-};


### PR DESCRIPTION
Hey @flexdinesh!

Really enjoyed your Twitter thread and this little experiment.

Suggestion to use `presets` instead of manually merging your config objects:

https://tailwindcss.com/docs/presets

One of the great advantages of doing this is you'll get the vscode Intellisense extension working in your app (and different ds packages) 🎉

<img width="709" alt="image" src="https://user-images.githubusercontent.com/485747/163118279-e1c6ef07-c4b8-4584-86c0-ca188798836c.png">

Also, I've changed the `theme` plugin code to generate the CSS variables scoped to the `body` element into the `base` layer instead of the `utilities` layer:

https://tailwindcss.com/docs/adding-base-styles

Those styles are not utility classes you'd apply on any element, and would want modifiers for different breakpoints, hover states, etc, so it makes more sense to inject them into the `base` styles, alongside the CSS reset and base styles.

Hope it helps 👍